### PR TITLE
Rewrote the script to add environment variables from the .env.properties file

### DIFF
--- a/gradle/environment.gradle.kts
+++ b/gradle/environment.gradle.kts
@@ -1,14 +1,10 @@
 fun configureEnvironment(task: ProcessForkOptions) {
     val f = File("${rootProject.projectDir}/.env.properties")
     if (f.isFile) {
-        f.readLines().forEachIndexed { index, line ->
-            if (line.isNotEmpty() && !line.startsWith("#")) {
-                val pair = line.split("=", limit = 2)
-                if (pair.size != 2) {
-                    project.logger.error("Error in .env.properties on line ${index+1}: '$line'")
-                }
-                task.environment[pair[0]] = pair[1]
-            }
+        val props = java.util.Properties()
+        f.inputStream().use { props.load(it) }
+        props.forEach { key, value ->
+            task.environment[key.toString()] = value.toString()
         }
     }
 }


### PR DESCRIPTION
Rewrote the script to add environment variables from the .env.properties file so that it is parsed by the java.util.Properties class instead of the more error-prone manual parsing.